### PR TITLE
Specify bash in the shebang

### DIFF
--- a/bin/tinypng
+++ b/bin/tinypng
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 #
 # Setup.


### PR DESCRIPTION
`#!/usr/bin/env sh` only works if the user happens to use bash, but not in dash or zsh etc.
This file is written for bash and contains several bashisms so it should explicitly use bash and not whatever shell is defined in the users env. Even using /bin/sh would not be correct as several distros including Ubuntu now symlinks sh to dash rather than bash.

